### PR TITLE
Add Provider model and OrganisationProvider join model

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,10 +21,33 @@ db.sequelize.sync().then(function() {
   app.listen(port, function() {
     console.log('Listening on port ' + port);
 
-    db.Provider.create( { email: 'alan@bookmiplace.com' } )
-    .then((provider) => {
-      console.log('provider ' + provider);
-    });
+    // let prov, org;
+    // db.Provider.create( { email: 'alan@bookmiplace.com' } )
+    // .then((provider) => {
+    //   console.log('provider ' + provider);
+    //   prov = provider;
+    // })
+    // .then(() => {
+    //   db.Organisation.create( { name: 'My Org' } )
+    //   .then((organisation) => {
+    //     console.log('organisation ' + organisation);
+    //     org = organisation;
+    //   })
+    //   .then(() => {
+    //     console.log('org.id ' + org.id);
+    //     console.log('prov.id ' + prov.id);
+
+    //     db.OrganisationProvider.create( 
+    //       { 
+    //         organisation_id: org.id, 
+    //         provider_id: prov.id
+    //       }
+    //     )
+    //     .then((organisation_provider) => {
+    //       console.log('organisation_provider ' + organisation_provider);
+    //     });
+    //   });
+    // });
 
   });
 });

--- a/app.js
+++ b/app.js
@@ -20,5 +20,11 @@ app.use(require('./controllers'));
 db.sequelize.sync().then(function() {
   app.listen(port, function() {
     console.log('Listening on port ' + port);
+
+    db.Provider.create( { email: 'alan@bookmiplace.com' } )
+    .then((provider) => {
+      console.log('provider ' + provider);
+    });
+
   });
 });

--- a/db/migrations/20180401095033-create-provider.js
+++ b/db/migrations/20180401095033-create-provider.js
@@ -1,0 +1,37 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('Providers', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      email: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      password: {
+        type: Sequelize.STRING
+      },
+      name: {
+        type: Sequelize.STRING
+      },
+      phoneNumber: {
+        type: Sequelize.STRING
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('Providers');
+  }
+};

--- a/db/migrations/20180401101446-create-organisation-provider.js
+++ b/db/migrations/20180401101446-create-organisation-provider.js
@@ -1,0 +1,45 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('OrganisationProviders', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      organisation_id: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+        references: {
+           model: 'Organisations',
+           key: 'id'
+         }
+      },
+      provider_id: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+        references: {
+           model: 'Providers',
+           key: 'id'
+         }
+      },
+      owner: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+        allowNull: false
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('OrganisationProviders');
+  }
+};

--- a/models/organisationprovider.js
+++ b/models/organisationprovider.js
@@ -1,0 +1,11 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  var OrganisationProvider = sequelize.define('OrganisationProvider', {
+    owner: DataTypes.BOOLEAN
+  }, {});
+  OrganisationProvider.associate = function(models) {
+    OrganisationProvider.belongsTo(models.Organisation, { foreignKey: 'organisation_id' });
+    OrganisationProvider.belongsTo(models.Provider, { foreignKey: 'provider_id' });
+  };
+  return OrganisationProvider;
+};

--- a/models/provider.js
+++ b/models/provider.js
@@ -1,0 +1,13 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  var Provider = sequelize.define('Provider', {
+    email: DataTypes.STRING,
+    password: DataTypes.STRING,
+    name: DataTypes.STRING,
+    phoneNumber: DataTypes.STRING
+  }, {});
+  Provider.associate = function(models) {
+    // associations can be defined here
+  };
+  return Provider;
+};


### PR DESCRIPTION
#### What's this PR do?
Adds Provider model and OrganisationProvider join model

##### Background context
Building out the models from [here](https://docs.google.com/presentation/d/1Xilql2vzIe8jNsuiGR6r1aN5_45nUQpMgRAUIAXAMqU/edit#slide=id.p)
Have stashed work on creating polymorphic membership model on [other branch](https://github.com/BookMiPlace/BookMiPlace/tree/add-polymorphic-membership-model) for now.
Have simplified the data modelling by incorporating employee and provider into one model: provider.
And added owner boolean field to OrganisationProvider join model.
All "employees" will have this set to false.

#### Where should the reviewer start?
db/migrations/*
models/*

#### How should this be manually tested?
Not really plumbed in yet. 
Have left in commented out code that successfully creates organisation, provider and OrganisationProvider models - just for the record.

#### Screenshots
n/a

#### Migrations
Yes - 2.
`sequelize db:migrate`

#### Additional deployment instructions
Any issues with DB, just drop DB and recreate:
```
$ dropdb book_mi_place_development
$ createdb book_mi_place_development
```

#### Additional ENV Vars
None
